### PR TITLE
Fix relative path for IR data

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
 # IR-Curve-Fitting
-For developing the research of reveal the structure of solution smoothly
+For developing the research of reveal the structure of solution smoothly.
+
+The Jupyter notebook `ir_fit.ipynb` loads the experimental data from the
+Excel file `ir_experiment.xlsx`. Place this file in the same directory as the
+notebook (the repository root) so the relative path `./ir_experiment.xlsx`
+works correctly.

--- a/ir_fit.ipynb
+++ b/ir_fit.ipynb
@@ -38,7 +38,7 @@
     "from scipy.optimize import least_squares\n",
     "\n",
     "# === 1. Load Data ===\n",
-    "df = pd.read_excel(\"/Users/solchem2018-imac/Documents/研究室/Python/ir_experiment.xlsx\")\n",
+    "df = pd.read_excel(\"./ir_experiment.xlsx\")\n",
     "df.columns = df.columns.str.strip()\n",
     "abs_cols = [c for c in df.columns if c not in ['Wavenumber','FA']]\n",
     "x = df['Wavenumber'].values\n",


### PR DESCRIPTION
## Summary
- load Excel data from `./ir_experiment.xlsx` in `ir_fit.ipynb`
- document expected location of Excel file in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684125659b988329b7ff39cd398bdbca